### PR TITLE
Run Miden Prover on multiple cores, same as Risc Zero

### DIFF
--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 miden-vm = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.6.1" }
-miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.6.1" }
+miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.6.1", features = ["concurrent"] }
 miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm", tag = "v0.6.1" }
 
 [dev-dependencies]


### PR DESCRIPTION
I think this is more fair. Alternatively we can run both on a single core.