### PR TITLE
ENG-1209: Check warnings and errors on CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Cache cargo bin
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/bin
           key: ${{ runner.os }}-cargo-bin-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Cache cargo bin
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
           key: ${{ runner.os }}-cargo-bin-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -46,7 +46,7 @@ jobs:
     needs: start-runner
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -85,7 +85,7 @@ jobs:
     needs: start-runner
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -124,7 +124,7 @@ jobs:
     needs: start-runner
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -174,7 +174,7 @@ jobs:
     needs: start-runner
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -210,7 +210,7 @@ jobs:
     needs: start-runner
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -237,7 +237,7 @@ jobs:
     needs: [polylang, miden, risc_zero, noir]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download benchmarks artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Cache cargo bin
         uses: actions/cache@v3
         with:
-          path: ~/.cargo/bin
+          path: /home/runner/.cargo/bin
           key: ${{ runner.os }}-cargo-bin-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install risczero

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - uses: Swatinem/rust-cache@v2
   
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - uses: Swatinem/rust-cache@v2
   
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: Swatinem/rust-cache@v2
 
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: Swatinem/rust-cache@v2
 
@@ -113,7 +113,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - uses: Swatinem/rust-cache@v2
   

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Cache cargo bin
         uses: actions/cache@v3
         with:
-          path: ~/.cargo/bin
+          path: /home/runner/.cargo/bin
           key: ${{ runner.os }}-cargo-bin-${{ hashFiles('**/Cargo.lock') }}
     
       - name: Install risczero

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Cache cargo bin
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/bin
           key: ${{ runner.os }}-cargo-bin-${{ hashFiles('**/Cargo.lock') }}
@@ -83,7 +83,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Cache Nix packages
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: /nix/store
           key: ${{ runner.os }}-nix-${{ hashFiles('**/shell.nix') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Cache cargo bin
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
           key: ${{ runner.os }}-cargo-bin-${{ hashFiles('**/Cargo.lock') }}
@@ -83,7 +83,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Cache Nix packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /nix/store
           key: ${{ runner.os }}-nix-${{ hashFiles('**/shell.nix') }}


### PR DESCRIPTION
Changes:
  - updated actions from v2 to v4.
  - updated actions/cache from v2 to ~~v4~~v3.
  - updated `~/.cargo/bin` to absolute path, `/home/runner` for permissions error. 