### PR TITLE
ENG-1216: Fix cargo fmt issue for `miden` package

### DIFF
--- a/miden/src/merkle.rs
+++ b/miden/src/merkle.rs
@@ -3,7 +3,7 @@ use miden_crypto::merkle::InnerNodeInfo;
 use miden_processor::{AdviceInputs, MemAdviceProvider, StackInputs, VmStateIterator};
 use miden_prover::{ExecutionProof, ProofOptions};
 use shared::{
-    hash::{HashFn, rpo::Rpo},
+    hash::{rpo::Rpo, HashFn},
     Tree,
 };
 


### PR DESCRIPTION
Changes:
  - Ran `cargo fmt` on the `miden` package.
  - double-checked using `cargo fmt --check` on all other packages.